### PR TITLE
fix: permission issue + bulkDelete error

### DIFF
--- a/src/commands/moderation/clear.js
+++ b/src/commands/moderation/clear.js
@@ -1,40 +1,44 @@
 const { color } = require('../../data/config.json');
-const { SlashCommandBuilder, PermissionFlagsBits, PermissionsBitField, EmbedBuilder } = require('discord.js');
+const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
 
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('clear')
         .setDescription('deletes a specified amount of messages in a channel')
-        .addNumberOption(option => option.setName('amount').setDescription('define amount of messages to delete').setRequired(true))
+        .addNumberOption(option =>
+            option
+            .setName('amount')
+            .setDescription('define amount of messages to delete')
+            .setRequired(true)
+            .setMinValue(1)
+            .setMaxValue(100))
 		.setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages)
 		.setDMPermission(false),
 
-        async execute(interaction) {
-            await interaction.deferReply({ ephemeral: true });
-            let amount = interaction.options.getNumber('amount');
-            if (interaction.member.permissions.has(PermissionsBitField.Flags.ManageMessages)) {
-                if (amount > 0) {
-                    if (amount > 100) {
-                        amount = 100;
-                    }
-                    const messages = await interaction.channel.messages.fetch({ limit: amount });
-                    await interaction.channel.bulkDelete(messages);
-                    const embed = new EmbedBuilder()
-                        .setTitle(`Deleted ${messages.size} messages! 🧹`)
-                        .setColor(color)
-                        .setThumbnail("https://eckigerluca.com/darling/media/cleaning.gif");
-                    await interaction.editReply({ embeds: [embed], ephemeral: true });
-                    await new Promise(resolve => setTimeout(resolve, 6000));
-                    return;
-                }
-                else {
-                    await interaction.editReply({ content: "Please define a number that is bigger than 0. Max. = 100", ephemeral: true });
-                    return;
-                }
-            }
-            else {
-                await interaction.editReply({ content: "I'm sorry, but you're not allowed to do that!", ephemeral: true });
-                return;
-            }
+    async execute(interaction) {
+        await interaction.deferReply({ ephemeral: true });
+        if (!interaction.guild.members.me.permissions.has(PermissionFlagsBits.ManageMessages)) {
+            await interaction.editReply({ content: "I'm sorry, but I'm missing permission to do that!" });
+            return;
+        }
+        if (!interaction.member.permissions.has(PermissionFlagsBits.ManageMessages)) {
+            await interaction.editReply({ content: "I'm sorry, but you're not allowed to do that!" });
+            return;
+        }
+
+        const amount = interaction.options.getNumber('amount');
+        const messages = await interaction.channel.messages.fetch({ limit: amount });
+        if (messages.find(msg => Date.now() - msg.createdAt >= 1000 * 60 * 60 * 24 * 14)) {
+            await interaction.editReply({ content: "I'm sorry, but I can't delete messages which are older than 14 days!" });
+            return;
+        }
+
+        await interaction.channel.bulkDelete(messages);
+        const embed = new EmbedBuilder()
+            .setTitle(`Deleted ${messages.size} messages! 🧹`)
+            .setColor(color)
+            .setThumbnail("https://eckigerluca.com/darling/media/cleaning.gif");
+        await interaction.editReply({ embeds: [embed] });
+        await new Promise(resolve => setTimeout(resolve, 6000));
     },
 };


### PR DESCRIPTION
## Fixes:
- Missing permissions results in error (e.g. added bot to guild without admin perm)
- Messages older than 14 Days can't be deleted by `bulkDelete()`

## Refactoring:
- Use `PermissionFlagsBits` instead of `PermissionsBitField`
- Define limits in SlashCommandBuilder instead of checking for them
- Remove ephemeral option from reply edits as ephemeral states set in `deferReply` can't be changed anyway